### PR TITLE
Add more output information

### DIFF
--- a/simple-converter/convert-opj.py
+++ b/simple-converter/convert-opj.py
@@ -50,7 +50,8 @@ else:
           ojp.opj_compress(image, jp2files + "/" + Path(image).resolve().stem + ".jp2",
             openjpeg_options=openjpeg.LOSSLESS_COMPRESS_OPTIONS)
         except:
-          print 'Conversion failed at record: ', position
+          print 'Conversion failed at ' + path  + '; record: ', position
+          sys.exit()
 
 # To time this process, you can use:
 #  /usr/bin/time -f "%e" ./convert-ojp.py sample_tiffs.txt


### PR DESCRIPTION
Output the name of the file that failed along with its index number to make tracking it down and (temporarily) removing it easier.